### PR TITLE
Initial infrastructure

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+[*]
+indent_style = space
+indent_size = 4
+
+[*.yaml]
+indent_size = 2
+
+[*.yml]
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: check-merge-conflict
+      - id: check-json
+      - id: check-yaml
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+  - repo: https://github.com/python-jsonschema/check-jsonschema
+    rev: 0.28.3
+    hooks:
+      - id: check-github-workflows
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v4.0.0-alpha.8
+    hooks:
+      - id: prettier
+        files: '.*\.(json|yaml|yml)$'
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.40.0
+    hooks:
+      - id: markdownlint
+        args: ["--disable", "MD013", "--"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
-# healthgps-data
-Input data for the Health-GPS program
+# Health-GPS input data
+
+This repository contains input data for the [Health-GPS] program.
+
+[Health-GPS]: https://github.com/imperialCHEPI/healthgps


### PR DESCRIPTION
Add initial infrastructure to the data repo.

Nothing exciting here. I was in two minds about whether to bother asking for a review but I thought it's probably best practice...

I haven't added the actual data files in this PR because I didn't want to bloat the diff. I'll do it separately.

Once this is done I intend to add some CI hooks to publish the input data as a zip file on release.