### PR TITLE
CI: Check `index.json` with `check-jsonschema`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,21 @@
+name: Dependabot and Pre-commit auto-merge
+
+on:
+  pull_request:
+
+permissions:
+  contents: write
+  pull-requests: write # Needed if in a private repository
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' || github.actor == 'pre-commit-ci[bot]' }}
+    steps:
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          # GitHub provides this variable in the CI env. You don't
+          # need to add anything to the secrets vault.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate-index-json.yml
+++ b/.github/workflows/validate-index-json.yml
@@ -18,6 +18,6 @@ jobs:
           python-version: "3.12"
           cache: pip
       - name: Install dependencies
-        run: pip install check-jsonschema
+        run: pip install -r requirements.txt
       - name: Validate index.json
         run: check-jsonschema data/index.json --schemafile https://raw.githubusercontent.com/imperialCHEPI/healthgps/main/schemas/v1/data_index.json

--- a/.github/workflows/validate-index-json.yml
+++ b/.github/workflows/validate-index-json.yml
@@ -1,0 +1,23 @@
+name: Validate index.json
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * 1" # midnight every Monday
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install dependencies
+        run: pip install check-jsonschema
+      - name: Validate index.json
+        run: check-jsonschema data/index.json --schemafile https://raw.githubusercontent.com/imperialCHEPI/healthgps/main/schemas/v1/data_index.json

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+check-jsonschema


### PR DESCRIPTION
This PR adds a CI workflow to validate `data/index.json` against the schema in the main HealthGPS repo. It runs on pull requests, pushes to `main` and is also scheduled to run once a week, to catch any errors introduced by changes to the schema (while published schemas shouldn't change, we might change things while things are under development).

Once I've added JSON schemas for the config files, hopefully we can reuse some of this infrastructure to check the files in the examples repo too.

Closes https://github.com/imperialCHEPI/healthgps-data/issues/3.