### PR TITLE
Create + upload zip file with checksum on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: Release
+run-name: Publishing release ${{ github.ref_name }}
+on:
+  release:
+    types: [published]
+jobs:
+  generate-release-artifacts:
+    name: Generate release artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Zip data directory
+        working-directory: data
+        run: zip -r ../data_${{ github.ref_name }}.zip
+      - name: Calculate SHA256 sum
+        run: sha256sum data_${{ github.ref_name }}.zip > sha256sum.txt
+      - name: Upload sha256sum file
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            data_${{ github.ref_name }}.zip
+            sha256sum.txt


### PR DESCRIPTION
This will mean there's a stable URL from which HealthGPS can download the static data. I'm doing this task before some of the others so that we have this URL to use.

Unfortunately, I can't think of a good way to test that this actually works except by merging it and trying it out.

Closes #6.