### PR TITLE
Fix release workflow (again)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Zip data directory
         working-directory: data
-        run: zip -r ../data_${{ github.ref_name }}.zip
+        run: zip -r ../data_${{ github.ref_name }}.zip *
       - name: Calculate SHA256 sum
         run: sha256sum data_${{ github.ref_name }}.zip > sha256sum.txt
       - name: Upload sha256sum file


### PR DESCRIPTION
It turns out we weren't actually zipping any files. Oops.